### PR TITLE
Fix shuffle button selector (#6)

### DIFF
--- a/src/constants/selectors.js
+++ b/src/constants/selectors.js
@@ -20,7 +20,7 @@ export const controlsSelectors = {
   playPause: '[data-id="play-pause"]',
   repeat: '[data-id="repeat"]',
   rewind: '[data-id="rewind"]',
-  shuffle: '[data-id="shuffle"]',
+  shuffle: '#player [data-id="shuffle"]',
   progress: '#material-player-progress',
 };
 


### PR DESCRIPTION
For #6: specifically target shuffle button in the player bar to prevent it getting the shuffle album/playlist button at the top instead.